### PR TITLE
Subclass NSObject for Lockbox

### DIFF
--- a/Lockbox.h
+++ b/Lockbox.h
@@ -5,7 +5,7 @@
 //  Copyright (c) 2012 Hawk iMedia. All rights reserved.
 //
 
-@interface Lockbox
+@interface Lockbox : NSObject
 
 +(BOOL)setString:(NSString *)value forKey:(NSString *)key;
 +(NSString *)stringForKey:(NSString *)key;


### PR DESCRIPTION
Thanks for making Lockbox!

I ran into an issue when using this with RubyMotion. I was receiving the following error:

``` console
(main)> Lockbox.class
2012-07-10 06:57:06.400 app[96021:15203] *** NSInvocation: warning: object 0x246030 of class 'Lockbox' does not implement methodSignatureForSelector: -- trouble ahead
```

This error seems to stem from the Lockbox class not subclass NSObject. Making Lockbox subclass NSObject fixes the issue for me.
