### PR TITLE
Add support for using a custom kSecAttrAccessible for all setter methods.

### DIFF
--- a/Lockbox.h
+++ b/Lockbox.h
@@ -8,12 +8,15 @@
 @interface Lockbox : NSObject
 
 +(BOOL)setString:(NSString *)value forKey:(NSString *)key;
++(BOOL)setString:(NSString *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
 +(NSString *)stringForKey:(NSString *)key;
 
 +(BOOL)setArray:(NSArray *)value forKey:(NSString *)key;
++(BOOL)setArray:(NSArray *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
 +(NSArray *)arrayForKey:(NSString *)key;
 
 +(BOOL)setSet:(NSSet *)value forKey:(NSString *)key;
++(BOOL)setSet:(NSSet *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
 +(NSSet *)setForKey:(NSString *)key;
 
 @end

--- a/Lockbox.m
+++ b/Lockbox.m
@@ -9,6 +9,7 @@
 #import <Security/Security.h>
 
 #define kDelimeter @"-|-"
+#define DEFAULT_ACCESSIBILITY kSecAttrAccessibleWhenUnlocked
 
 #if __has_feature(objc_arc)
 #define ID __bridge id
@@ -51,7 +52,7 @@ static NSString *_bundleId = nil;
     return [_bundleId stringByAppendingFormat:@".%@", key];
 }
 
-+(BOOL)setObject:(NSString *)obj forKey:(NSString *)key
++(BOOL)setObject:(NSString *)obj forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
 {
     OSStatus status;
     
@@ -71,6 +72,7 @@ static NSString *_bundleId = nil;
     
     NSMutableDictionary *dict = [self _service];
     [dict setObject: hierKey forKey: (ID) kSecAttrService];
+    [dict setObject: accessibility forKey: (ID) kSecAttrAccessible];
     [dict setObject: [obj dataUsingEncoding:NSUTF8StringEncoding] forKey: (ID) kSecValueData];
     
 #if __has_feature(objc_arc)
@@ -138,7 +140,12 @@ static NSString *_bundleId = nil;
 
 +(BOOL)setString:(NSString *)value forKey:(NSString *)key
 {
-    return [self setObject:value forKey:key];
+    return [self setString:value forKey:key accessibility:DEFAULT_ACCESSIBILITY];
+}
+
++(BOOL)setString:(NSString *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
+{
+    return [self setObject:value forKey:key accessibility:accessibility];
 }
 
 +(NSString *)stringForKey:(NSString *)key
@@ -148,8 +155,13 @@ static NSString *_bundleId = nil;
 
 +(BOOL)setArray:(NSArray *)value forKey:(NSString *)key
 {
+    return [self setArray:value forKey:key accessibility:DEFAULT_ACCESSIBILITY];
+}
+
++(BOOL)setArray:(NSArray *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
+{
     NSString *components = [value componentsJoinedByString:kDelimeter];
-    return [self setObject:components forKey:key];
+    return [self setObject:components forKey:key accessibility:accessibility];
 }
 
 +(NSArray *)arrayForKey:(NSString *)key
@@ -164,7 +176,12 @@ static NSString *_bundleId = nil;
 
 +(BOOL)setSet:(NSSet *)value forKey:(NSString *)key
 {
-    return [self setArray:[value allObjects] forKey:key];
+    return [self setSet:value forKey:key accessibility:DEFAULT_ACCESSIBILITY];
+}
+
++(BOOL)setSet:(NSSet *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
+{
+    return [self setArray:[value allObjects] forKey:key accessibility:accessibility];
 }
 
 +(NSSet *)setForKey:(NSString *)key

--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ One caveat here is that the keychain is really not meant to store large chunks o
 There are three pairs of methods, but method pairs for other container classes would not be hard to implement:
 
 + `+setString:forKey:`
++ `+setString:forKey:accessibility:`
 + `+stringForKey:`
 + `+setArray:forKey:`
++ `+setArray:forKey:accessibility:`
 + `+arrayForKey:`
 + `+setSet:forKey:`
++ `+setSet:forKey:accessibility:`
 + `+setForKey:`
 
 All the `setXxx` methods return `BOOL`, indicating if the keychain operation succeeded or failed. The `xxxForKey` methods return a non-`nil` value on success, or `nil` on failure.
@@ -35,6 +38,8 @@ All the `setXxx` methods return `BOOL`, indicating if the keychain operation suc
 The `setXxx` methods will overwrite values for keys that already exist in the keychain, or simply add a keychain entry for the key/value pair if it's not already there.
 
 In all the methods you can use a simple key name, like "MyKey", but know that under the hood Lockbox is prefixing that key with your apps bundle id. So the actual key used to store and retrieve the data looks more like "com.mycompany.myapp.MyKey". This ensures that your app, and only your app, has access to your data.
+
+The methods with a `accessibility` argument take a [Keychain Item Accessibility Constant](http://developer.apple.com/library/ios/#DOCUMENTATION/Security/Reference/keychainservices/Reference/reference.html#//apple_ref/doc/uid/TP30000898-CH4g-SW318). You can use this to control the when your keychain item should be readable. For example, passing `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` will make it accessible only while the device is unlocked, and will not migrate this item to a new device or installation. The methods without a specific `accessibility` will use `kSecAttrAccessibleWhenUnlocked`, the default in recent iOS versions.
 
 ## Requirements
 


### PR DESCRIPTION
This patch adds support using a custom accessibility setting on a keychain item. This is very useful, because it allows a user to tighten down security further (e.g. not allowing an item to migrate to a new device), or make it more loose to allow, for example, using the item from background tasks.

The code changes are backwards compatible, there are no changes in functionality for existing calls.
