### PR TITLE
Doesn't NSLog SecItemCopyMatching failed if not found in objectForKey

### DIFF
--- a/Lockbox.m
+++ b/Lockbox.m
@@ -97,7 +97,7 @@ static NSString *_bundleId = nil;
     CFDataRef data = nil;
     OSStatus status =
     SecItemCopyMatching ( (LOCKBOX_DICTREF) query, (CFTypeRef *) &data );
-    if (status != errSecSuccess)
+    if (status != errSecSuccess && status != errSecItemNotFound)
         NSLog(@"SecItemCopyMatching failed for key %@: %ld", hierKey, status);
     
     if (!data)


### PR DESCRIPTION
SecItemCopyMatching can return the item not found code. In the objectForKey method, having it NSLog "failed" if an item is not found can lead to endless log statements if objectForKey is used repeatedly.
