### PR TITLE
Remove "key" property from console log.

### DIFF
--- a/Lockbox.m
+++ b/Lockbox.m
@@ -198,7 +198,7 @@ static NSString *_bundleId = nil;
     
     if ((keysAndValues.count % 2) != 0)
     {
-        NSLog(@"Dictionary for %@ was not saved properly to keychain", key);
+        NSLog(@"Dictionary was not saved properly to keychain");
         return nil;
     }
     


### PR DESCRIPTION
@discussion just to be safe, it's not necessary to log the "key" property's value as anyone who profiles your app could potentially get the value by watching the console
