### PR TITLE
Custom Key Prefix

### DIFF
--- a/LockBox/LockBox/ViewController.m
+++ b/LockBox/LockBox/ViewController.m
@@ -21,6 +21,8 @@
 
 @interface ViewController ()
 
+@property (nonatomic, strong) Lockbox *lockbox;
+
 @end
 
 @implementation ViewController
@@ -29,6 +31,14 @@
 @synthesize fetchButton;
 @synthesize fetchedValueLabel;
 @synthesize statusLabel;
+
+-(instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+{
+    if (self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil]) {
+        self.lockbox = [[Lockbox alloc] init];
+    }
+    return self;
+}
 
 - (void)viewDidLoad
 {
@@ -57,7 +67,7 @@
     
     switch (b.tag) {
         case kSaveAsString:
-            result = [Lockbox setString:value forKey:kMyKeyString];
+            result = [self.lockbox setString:value forKey:kMyKeyString];
             break;
             
         case kSaveAsArray:
@@ -68,7 +78,7 @@
                               [value stringByAppendingString:@" 2"], 
                               [value stringByAppendingString:@" 3"],
                               nil];
-            result = [Lockbox setArray:array forKey:kMyKeyArray];
+            result = [self.lockbox setArray:array forKey:kMyKeyArray];
             break;
         }
             
@@ -80,7 +90,7 @@
                           [value stringByAppendingString:@" 2"], 
                           [value stringByAppendingString:@" 3"],
                           nil];
-            result = [Lockbox setSet:set forKey:kMyKeySet];
+            result = [self.lockbox setSet:set forKey:kMyKeySet];
             break;
         }
             
@@ -90,7 +100,7 @@
             NSDictionary * dictionary = value ? @{@"key 1" : [value stringByAppendingString:@" 1"],
                                                   @"key 2" : [value stringByAppendingString:@" 2"],
                                                   @"key 3" : [value stringByAppendingString:@" 3"]} : nil;
-            result = [Lockbox setDictionary:dictionary forKey:kMyKeyDictionary];
+            result = [self.lockbox setDictionary:dictionary forKey:kMyKeyDictionary];
             break;
         }
             
@@ -113,26 +123,26 @@
     
     switch (b.tag) {
         case kSaveAsString:
-            value = [Lockbox stringForKey:kMyKeyString];
+            value = [self.lockbox stringForKey:kMyKeyString];
             break;
             
         case kSaveAsArray:
         {
-            NSArray *array = [Lockbox arrayForKey:kMyKeyArray];
+            NSArray *array = [self.lockbox arrayForKey:kMyKeyArray];
             value = [array componentsJoinedByString:@"\n"];
             break;
         }
             
         case kSaveAsSet:
         {
-            NSSet *set = [Lockbox setForKey:kMyKeySet];
+            NSSet *set = [self.lockbox setForKey:kMyKeySet];
             value = [[set allObjects] componentsJoinedByString:@"\n"];
             break;
         }
             
         case kSaveAsDictionary:
         {
-            NSDictionary * dictionary = [Lockbox dictionaryForKey:kMyKeyDictionary];
+            NSDictionary * dictionary = [self.lockbox dictionaryForKey:kMyKeyDictionary];
             value = dictionary.description;
             break;
         }

--- a/LockBox/UnitTests/LockboxTests.m
+++ b/LockBox/UnitTests/LockboxTests.m
@@ -15,6 +15,7 @@
 
 @implementation LockboxTests
 {
+    Lockbox *lockbox;
     NSString *testString;
     NSArray *testArray;
     NSSet *testSet;
@@ -24,6 +25,7 @@
 
 -(void)setUp
 {
+    lockbox = [[Lockbox alloc] init];
     testString = @"TestString";
     testArray = @[ @"A", @"B", @"C" ];
     testSet = [NSSet setWithArray:testArray];
@@ -41,8 +43,8 @@
 -(void)testSetStringForKey
 {
     NSString *key = @"TestStringKey";
-    XCTAssertTrue([Lockbox setString:testString forKey:key], @"Should be able to store a string");
-    XCTAssertEqualObjects([Lockbox stringForKey:key], testString, @"Retrieved string should match original");
+    XCTAssertTrue([lockbox setString:testString forKey:key], @"Should be able to store a string");
+    XCTAssertEqualObjects([lockbox stringForKey:key], testString, @"Retrieved string should match original");
     
     [NSThread sleepForTimeInterval:1.0];
 }
@@ -50,17 +52,17 @@
 -(void)testDeleteStringForKey
 {
     NSString *key = @"TestStringKey";
-    XCTAssertTrue([Lockbox setString:testString forKey:key], @"Should be able to store a string");
-    XCTAssertEqualObjects([Lockbox stringForKey:key], testString, @"Retrieved string should match original");
-    XCTAssertTrue([Lockbox setString:nil forKey:key], @"Should be able to set string for key to nil");
-    XCTAssertNil([Lockbox stringForKey:key], @"Deleted key should return nil");
+    XCTAssertTrue([lockbox setString:testString forKey:key], @"Should be able to store a string");
+    XCTAssertEqualObjects([lockbox stringForKey:key], testString, @"Retrieved string should match original");
+    XCTAssertTrue([lockbox setString:nil forKey:key], @"Should be able to set string for key to nil");
+    XCTAssertNil([lockbox stringForKey:key], @"Deleted key should return nil");
 }
 
 -(void)testSetArrayForKey
 {
     NSString *key = @"TestArrayKey";
-    XCTAssertTrue([Lockbox setArray:testArray forKey:key], @"Should be able to store an array");
-    NSArray *array = [Lockbox arrayForKey:key];
+    XCTAssertTrue([lockbox setArray:testArray forKey:key], @"Should be able to store an array");
+    NSArray *array = [lockbox arrayForKey:key];
     XCTAssertEqualObjects(array, testArray, @"Retrieved array should match original");
 
     [NSThread sleepForTimeInterval:1.0];
@@ -69,8 +71,8 @@
 -(void)testSetSetForKey
 {
     NSString *key = @"TestSetKey";
-    XCTAssertTrue([Lockbox setSet:testSet forKey:key], @"Should be able to store a set");
-    NSSet *set = [Lockbox setForKey:key];
+    XCTAssertTrue([lockbox setSet:testSet forKey:key], @"Should be able to store a set");
+    NSSet *set = [lockbox setForKey:key];
     XCTAssertEqualObjects(set, testSet, @"Retrieved set should match original");
     
     [NSThread sleepForTimeInterval:1.0];
@@ -79,8 +81,8 @@
 -(void)testSetDictionaryForKey
 {
     NSString *key = @"TestDictionaryKey";
-    XCTAssertTrue([Lockbox setDictionary:testDictionary forKey:key], @"Should be able to store a dictionary");
-    NSDictionary *dictionary = [Lockbox dictionaryForKey:key];
+    XCTAssertTrue([lockbox setDictionary:testDictionary forKey:key], @"Should be able to store a dictionary");
+    NSDictionary *dictionary = [lockbox dictionaryForKey:key];
     XCTAssertEqualObjects(dictionary, testDictionary, @"Retrieved dictionary should match original");
     
     [NSThread sleepForTimeInterval:1.0];
@@ -88,61 +90,79 @@
 
 -(void)testSetSameKeyWithTwoValues
 {
-    XCTAssertTrue([Lockbox setString:@"1" forKey:@"test"], @"Set '1' for key 'test'");
-    XCTAssertTrue([[Lockbox stringForKey:@"test"] isEqualToString:@"1"], @"Retrieve '1' for key 'test'");
-    XCTAssertTrue([Lockbox setString:@"2" forKey:@"test"], @"Set '2' for key 'test'");
-    XCTAssertTrue([[Lockbox stringForKey:@"test"] isEqualToString:@"2"], @"Retrieve '2' for key 'test'");
+    XCTAssertTrue([lockbox setString:@"1" forKey:@"test"], @"Set '1' for key 'test'");
+    XCTAssertTrue([[lockbox stringForKey:@"test"] isEqualToString:@"1"], @"Retrieve '1' for key 'test'");
+    XCTAssertTrue([lockbox setString:@"2" forKey:@"test"], @"Set '2' for key 'test'");
+    XCTAssertTrue([[lockbox stringForKey:@"test"] isEqualToString:@"2"], @"Retrieve '2' for key 'test'");
 }
 
 -(void)testSetDateForKey
 {
     NSString *key = @"TestDateKey";
-    XCTAssertTrue([Lockbox setDate:testDate forKey:key], @"Should be able to store a date");
-    NSDate *date = [Lockbox dateForKey:key];
+    XCTAssertTrue([lockbox setDate:testDate forKey:key], @"Should be able to store a date");
+    NSDate *date = [lockbox dateForKey:key];
     XCTAssertEqualObjects(date, testDate, @"Retrieved date should match original");
 }
 
 -(void)testSetNoDateForKey
 {
     NSString *key = @"TestDateKey";
-    XCTAssertTrue([Lockbox setDate:nil forKey:key], @"Should be able to remove a stored date");
+    XCTAssertTrue([lockbox setDate:nil forKey:key], @"Should be able to remove a stored date");
 }
 
 -(void)testRetrieveDateForNoKey
 {
     NSString *key =@"NonexistentDateKey";
-    XCTAssertNil([Lockbox dateForKey:key], @"Should return nil (date) for nonexistent key");
+    XCTAssertNil([lockbox dateForKey:key], @"Should return nil (date) for nonexistent key");
 }
 
 -(void)testNilDictionary
 {
     NSString *key = @"testDict";
     NSDictionary *testDict = @{ @"test1" : @"value1", @"test2" : @"value2" };
-    XCTAssertTrue([Lockbox setDictionary:testDict forKey:key], @"Set Dictionary value for key 'testDict'");
+    XCTAssertTrue([lockbox setDictionary:testDict forKey:key], @"Set Dictionary value for key 'testDict'");
 
-    NSDictionary *savedDict = [Lockbox dictionaryForKey:key];
+    NSDictionary *savedDict = [lockbox dictionaryForKey:key];
     XCTAssertTrue(savedDict != nil, @"Retrieved Dictionary for key 'testDict'");
     XCTAssertTrue([savedDict allKeys].count == 2, @"Key count matches stored Dictionary");
     XCTAssertTrue([savedDict[@"test1"] isEqualToString:@"value1"], @"Retrieve Dictionary 'value1' for Dictionary key 'test1'");
     
-    XCTAssertTrue([Lockbox setDictionary:nil forKey:key], @"Setting Dictionary value to nil for key 'testDict'");
-    XCTAssertNil([Lockbox dictionaryForKey:key], @"Confirm Dictionary has been cleared from Lockbox");
+    XCTAssertTrue([lockbox setDictionary:nil forKey:key], @"Setting Dictionary value to nil for key 'testDict'");
+    XCTAssertNil([lockbox dictionaryForKey:key], @"Confirm Dictionary has been cleared from Lockbox");
 }
 
 - (void)testNilArray
 {
     NSString *key = @"testArr";
     NSArray *testArr = @[ @"value1", @"value2", @"value3" ];
-    XCTAssertTrue([Lockbox setArray:testArr forKey:key], @"Set Array value for key 'testArr'");
+    XCTAssertTrue([lockbox setArray:testArr forKey:key], @"Set Array value for key 'testArr'");
     
-    NSArray *savedArr = [Lockbox arrayForKey:key];
+    NSArray *savedArr = [lockbox arrayForKey:key];
     XCTAssertTrue(savedArr != nil, @"Retrieved Array for key 'testArr'");
     XCTAssertTrue(savedArr.count == 3, @"Array count matches stored Array");
     XCTAssertTrue([savedArr[1] isEqualToString:@"value2"], @"Retrieve Array value 'value2' at index 1");
     
-    XCTAssertTrue([Lockbox setArray:nil forKey:key], @"Setting Array value to nil for key 'testArr'");
-    XCTAssertNil([Lockbox arrayForKey:key], @"Confirm Array has been cleared from Lockbox");
+    XCTAssertTrue([lockbox setArray:nil forKey:key], @"Setting Array value to nil for key 'testArr'");
+    XCTAssertNil([lockbox arrayForKey:key], @"Confirm Array has been cleared from Lockbox");
 
+}
+
+- (void)testInitWithKeyPrefix
+{
+    lockbox = [[Lockbox alloc] initWithKeyPrefix:@"custom.key.prefix"];
+    
+    NSString *key = @"TestStringKey";
+    XCTAssertTrue([lockbox setString:testString forKey:key], @"Should be able to store a string");
+    XCTAssertEqualObjects([lockbox stringForKey:key], testString, @"Retrieved string should match original");
+}
+
+- (void)testInitWithNilKeyPrefix
+{
+    lockbox = [[Lockbox alloc] initWithKeyPrefix:nil];
+    
+    NSString *key = @"TestStringKey";
+    XCTAssertTrue([lockbox setString:testString forKey:key], @"Should be able to store a string");
+    XCTAssertEqualObjects([lockbox stringForKey:key], testString, @"Retrieved string should match original");
 }
 
 @end

--- a/Lockbox.h
+++ b/Lockbox.h
@@ -9,26 +9,27 @@
 
 @interface Lockbox : NSObject
 
-+(void)setKeyPrefix:(NSString *)keyPrefix;
+// Use this initialiser to override the default key prefix, the bundle id.
+-(instancetype)initWithKeyPrefix:(NSString *)keyPrefix;
 
-+(BOOL)setString:(NSString *)value forKey:(NSString *)key;
-+(BOOL)setString:(NSString *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
-+(NSString *)stringForKey:(NSString *)key;
+-(BOOL)setString:(NSString *)value forKey:(NSString *)key;
+-(BOOL)setString:(NSString *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
+-(NSString *)stringForKey:(NSString *)key;
 
-+(BOOL)setArray:(NSArray *)value forKey:(NSString *)key;
-+(BOOL)setArray:(NSArray *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
-+(NSArray *)arrayForKey:(NSString *)key;
+-(BOOL)setArray:(NSArray *)value forKey:(NSString *)key;
+-(BOOL)setArray:(NSArray *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
+-(NSArray *)arrayForKey:(NSString *)key;
 
-+(BOOL)setSet:(NSSet *)value forKey:(NSString *)key;
-+(BOOL)setSet:(NSSet *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
-+(NSSet *)setForKey:(NSString *)key;
+-(BOOL)setSet:(NSSet *)value forKey:(NSString *)key;
+-(BOOL)setSet:(NSSet *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
+-(NSSet *)setForKey:(NSString *)key;
 
-+(BOOL)setDictionary:(NSDictionary *)value forKey:(NSString *)key;
-+(BOOL)setDictionary:(NSDictionary *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
-+(NSDictionary *)dictionaryForKey:(NSString *)key;
+-(BOOL)setDictionary:(NSDictionary *)value forKey:(NSString *)key;
+-(BOOL)setDictionary:(NSDictionary *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
+-(NSDictionary *)dictionaryForKey:(NSString *)key;
 
-+(BOOL)setDate:(NSDate *)value forKey:(NSString *)key;
-+(BOOL)setDate:(NSDate *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
-+(NSDate *)dateForKey:(NSString *)key;
+-(BOOL)setDate:(NSDate *)value forKey:(NSString *)key;
+-(BOOL)setDate:(NSDate *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility;
+-(NSDate *)dateForKey:(NSString *)key;
 
 @end

--- a/Lockbox.m
+++ b/Lockbox.m
@@ -23,16 +23,33 @@
 #define LOCKBOX_ID __bridge id
 #define LOCKBOX_DICTREF __bridge CFDictionaryRef
 
-static NSString *_keyPrefix = nil;
+@interface Lockbox ()
+
+@property (nonatomic, strong) NSString *keyPrefix;
+
+@end
 
 @implementation Lockbox
 
-+(void)initialize
+-(instancetype)init
 {
-    _keyPrefix = [[[NSBundle bundleForClass:[self class]] infoDictionary] objectForKey:(NSString*)kCFBundleIdentifierKey];
+    if (self = [super init]) {
+        self.keyPrefix = [[[NSBundle bundleForClass:[self class]] infoDictionary] objectForKey:(NSString*)kCFBundleIdentifierKey];
+    }
+    return self;
 }
 
-+(NSMutableDictionary *)_service
+-(instancetype)initWithKeyPrefix:(NSString *)keyPrefix
+{
+    if (self = [self init]) {
+        if (keyPrefix) {
+            self.keyPrefix = keyPrefix;
+        }
+    }
+    return self;
+}
+
+-(NSMutableDictionary *)_service
 {
     NSMutableDictionary* dict = [NSMutableDictionary dictionary];
     
@@ -41,7 +58,7 @@ static NSString *_keyPrefix = nil;
     return dict;
 }
 
-+(NSMutableDictionary *)_query
+-(NSMutableDictionary *)_query
 {
     NSMutableDictionary* query = [NSMutableDictionary dictionary];
     
@@ -53,17 +70,12 @@ static NSString *_keyPrefix = nil;
 
 // Prefix a bare key like "MySecureKey", so the actual key stored is unique to this app,
 // e.g. "com.mycompany.myapp.MySecretKey". Default prefix is the bundle id.
-+(NSString *)_hierarchicalKey:(NSString *)key
+-(NSString *)_hierarchicalKey:(NSString *)key
 {
-    return [_keyPrefix stringByAppendingFormat:@".%@", key];
+    return [self.keyPrefix stringByAppendingFormat:@".%@", key];
 }
 
-+(void)setKeyPrefix:(NSString *)keyPrefix
-{
-    _keyPrefix = keyPrefix;
-}
-
-+(BOOL)setObject:(NSString *)obj forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
+-(BOOL)setObject:(NSString *)obj forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
 {
     OSStatus status;
     
@@ -96,7 +108,7 @@ static NSString *_keyPrefix = nil;
     return (status == errSecSuccess);
 }
 
-+(NSString *)objectForKey:(NSString *)key
+-(NSString *)objectForKey:(NSString *)key
 {
     NSString *hierKey = [self _hierarchicalKey:key];
 
@@ -117,27 +129,27 @@ static NSString *_keyPrefix = nil;
     return s;
 }
 
-+(BOOL)setString:(NSString *)value forKey:(NSString *)key
+-(BOOL)setString:(NSString *)value forKey:(NSString *)key
 {
     return [self setString:value forKey:key accessibility:DEFAULT_ACCESSIBILITY];
 }
 
-+(BOOL)setString:(NSString *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
+-(BOOL)setString:(NSString *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
 {
     return [self setObject:value forKey:key accessibility:accessibility];
 }
 
-+(NSString *)stringForKey:(NSString *)key
+-(NSString *)stringForKey:(NSString *)key
 {
     return [self objectForKey:key];
 }
 
-+(BOOL)setArray:(NSArray *)value forKey:(NSString *)key
+-(BOOL)setArray:(NSArray *)value forKey:(NSString *)key
 {
     return [self setArray:value forKey:key accessibility:DEFAULT_ACCESSIBILITY];
 }
 
-+(BOOL)setArray:(NSArray *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
+-(BOOL)setArray:(NSArray *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
 {
     NSString *components = nil;
     if (value != nil && value.count > 0) {
@@ -146,7 +158,7 @@ static NSString *_keyPrefix = nil;
     return [self setObject:components forKey:key accessibility:accessibility];
 }
 
-+(NSArray *)arrayForKey:(NSString *)key
+-(NSArray *)arrayForKey:(NSString *)key
 {
     NSArray *array = nil;
     NSString *components = [self objectForKey:key];
@@ -156,17 +168,17 @@ static NSString *_keyPrefix = nil;
     return array;
 }
 
-+(BOOL)setSet:(NSSet *)value forKey:(NSString *)key
+-(BOOL)setSet:(NSSet *)value forKey:(NSString *)key
 {
     return [self setSet:value forKey:key accessibility:DEFAULT_ACCESSIBILITY];
 }
 
-+(BOOL)setSet:(NSSet *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
+-(BOOL)setSet:(NSSet *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
 {
     return [self setArray:[value allObjects] forKey:key accessibility:accessibility];
 }
 
-+(NSSet *)setForKey:(NSString *)key
+-(NSSet *)setForKey:(NSString *)key
 {
     NSSet *set = nil;
     NSArray *array = [self arrayForKey:key];
@@ -176,12 +188,12 @@ static NSString *_keyPrefix = nil;
     return set;
 }
 
-+ (BOOL)setDictionary:(NSDictionary *)value forKey:(NSString *)key
+-(BOOL)setDictionary:(NSDictionary *)value forKey:(NSString *)key
 {
     return [self setDictionary:value forKey:key accessibility:DEFAULT_ACCESSIBILITY];
 }
 
-+ (BOOL)setDictionary:(NSDictionary *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
+-(BOOL)setDictionary:(NSDictionary *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
 {
     NSMutableArray * keysAndValues = [NSMutableArray arrayWithArray:value.allKeys];
     [keysAndValues addObjectsFromArray:value.allValues];
@@ -189,7 +201,7 @@ static NSString *_keyPrefix = nil;
     return [self setArray:keysAndValues forKey:key accessibility:accessibility];
 }
 
-+ (NSDictionary *)dictionaryForKey:(NSString *)key
+-(NSDictionary *)dictionaryForKey:(NSString *)key
 {
     NSArray * keysAndValues = [self arrayForKey:key];
     
@@ -209,12 +221,12 @@ static NSString *_keyPrefix = nil;
                                        forKeys:[keysAndValues subarrayWithRange:keys]];
 }
 
-+(BOOL)setDate:(NSDate *)value forKey:(NSString *)key
+-(BOOL)setDate:(NSDate *)value forKey:(NSString *)key
 {
     return [self setDate:value forKey:key accessibility:DEFAULT_ACCESSIBILITY];
 }
 
-+(BOOL)setDate:(NSDate *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
+-(BOOL)setDate:(NSDate *)value forKey:(NSString *)key accessibility:(CFTypeRef)accessibility
 {
     if (!value)
         return [self setObject:nil forKey:key accessibility:accessibility];
@@ -222,7 +234,7 @@ static NSString *_keyPrefix = nil;
     return [self setObject:[rti stringValue] forKey:key accessibility:accessibility];
 }
 
-+(NSDate *)dateForKey:(NSString *)key
+-(NSDate *)dateForKey:(NSString *)key
 {
     NSString *dateString = [self objectForKey:key];
     if (dateString)


### PR DESCRIPTION
I've made some changes to allow for a custom key prefix to be specified, defaulting to the bundle id.

The reason for this is that I am working with iOS app extensions, which have different bundle id's from the main app, but which need access to the keychain of the main app for login credentials.

The implementation is possibly a bit controversial, as I have changed Lockbox to be instantiable. The [first commit](https://github.com/bravedrake/Lockbox/commit/f7663fd9ff3231764b06f94f3ff2c6aa7bbf5143) simply added a class method, but this seemed unsafe, as setting this after calling some of the setters would mean that the prefix would change, and the previously set key/value pair would be unaccessible. Making the class instantiable means that the prefix has to be set up front, and cannot be changed.
