### PR TITLE
remove unused UIKit import from Lockbox.h

### DIFF
--- a/Lockbox.h
+++ b/Lockbox.h
@@ -5,8 +5,6 @@
 //  Copyright (c) 2012 Hawk iMedia. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-
 @interface Lockbox : NSObject
 
 #ifdef DEBUG


### PR DESCRIPTION
Remove the UIKit import from Lockbox.h as discussed in Issue #39 .