### PR TITLE
Add shared framework target to support Carthage

### DIFF
--- a/LockBox/LockBox.xcodeproj/project.pbxproj
+++ b/LockBox/LockBox.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		4D68021216B489AB000CED0E /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 4D68020F16B489AB000CED0E /* README.md */; };
 		4D917A0A1C593EC800323832 /* Lockbox3Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D917A091C593EC800323832 /* Lockbox3Tests.m */; };
 		4DE9819617FF3C3000E7D452 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 4DE9819517FF3C3000E7D452 /* Default-568h@2x.png */; };
+		FAD106491D961E9700F81263 /* Lockbox.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D0B9E811540558B00E5BE71 /* Lockbox.m */; };
+		FAD1064B1D96208400F81263 /* Lockbox.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D0B9E801540558B00E5BE71 /* Lockbox.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,6 +68,9 @@
 		4D917A091C593EC800323832 /* Lockbox3Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Lockbox3Tests.m; sourceTree = "<group>"; };
 		4DA5A23C1D897F9D0072168E /* LockBox.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LockBox.entitlements; sourceTree = "<group>"; };
 		4DE9819517FF3C3000E7D452 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
+		FAD106411D961E8900F81263 /* Lockbox.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Lockbox.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FAD106431D961E8900F81263 /* Lockbox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Lockbox.h; sourceTree = "<group>"; };
+		FAD106441D961E8900F81263 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -89,6 +94,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FAD1063D1D961E8900F81263 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -98,6 +110,7 @@
 				4DE9819517FF3C3000E7D452 /* Default-568h@2x.png */,
 				2D0B9E691540556E00E5BE71 /* LockBox */,
 				4D6801ED16B478CB000CED0E /* UnitTests */,
+				FAD106421D961E8900F81263 /* Lockbox */,
 				2D0B9E621540556E00E5BE71 /* Frameworks */,
 				2D0B9E601540556E00E5BE71 /* Products */,
 				4D68020C16B4896F000CED0E /* Misc Files */,
@@ -109,6 +122,7 @@
 			children = (
 				2D0B9E5F1540556E00E5BE71 /* LockBox.app */,
 				4D6801E816B478CB000CED0E /* UnitTests.xctest */,
+				FAD106411D961E8900F81263 /* Lockbox.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -181,7 +195,27 @@
 			name = "Misc Files";
 			sourceTree = "<group>";
 		};
+		FAD106421D961E8900F81263 /* Lockbox */ = {
+			isa = PBXGroup;
+			children = (
+				FAD106431D961E8900F81263 /* Lockbox.h */,
+				FAD106441D961E8900F81263 /* Info.plist */,
+			);
+			path = Lockbox;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		FAD1063E1D961E8900F81263 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FAD1064B1D96208400F81263 /* Lockbox.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		2D0B9E5E1540556E00E5BE71 /* LockBox */ = {
@@ -219,6 +253,24 @@
 			productReference = 4D6801E816B478CB000CED0E /* UnitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		FAD106401D961E8900F81263 /* Lockbox */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FAD106481D961E8900F81263 /* Build configuration list for PBXNativeTarget "Lockbox" */;
+			buildPhases = (
+				FAD1063C1D961E8900F81263 /* Sources */,
+				FAD1063D1D961E8900F81263 /* Frameworks */,
+				FAD1063E1D961E8900F81263 /* Headers */,
+				FAD1063F1D961E8900F81263 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Lockbox;
+			productName = Lockbox;
+			productReference = FAD106411D961E8900F81263 /* Lockbox.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -237,6 +289,11 @@
 							};
 						};
 					};
+					FAD106401D961E8900F81263 = {
+						CreatedOnToolsVersion = 8.0;
+						DevelopmentTeam = RXLRNL2RFQ;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 2D0B9E591540556D00E5BE71 /* Build configuration list for PBXProject "LockBox" */;
@@ -253,6 +310,7 @@
 			targets = (
 				2D0B9E5E1540556E00E5BE71 /* LockBox */,
 				4D6801E716B478CB000CED0E /* UnitTests */,
+				FAD106401D961E8900F81263 /* Lockbox */,
 			);
 		};
 /* End PBXProject section */
@@ -279,6 +337,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FAD1063F1D961E8900F81263 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -299,6 +364,14 @@
 			files = (
 				4D6801FD16B478F7000CED0E /* LockboxTests.m in Sources */,
 				4D917A0A1C593EC800323832 /* Lockbox3Tests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FAD1063C1D961E8900F81263 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FAD106491D961E9700F81263 /* Lockbox.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -356,7 +429,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
-				ENABLE_BITCODE = NO;
+				ENABLE_BITCODE = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -397,7 +470,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
-				ENABLE_BITCODE = NO;
+				ENABLE_BITCODE = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -506,6 +579,78 @@
 			};
 			name = Release;
 		};
+		FAD106461D961E8900F81263 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = RXLRNL2RFQ;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = Lockbox/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hawkimedia.Lockbox;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		FAD106471D961E8900F81263 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = RXLRNL2RFQ;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = Lockbox/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hawkimedia.Lockbox;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -532,6 +677,15 @@
 			buildConfigurations = (
 				4D6801F716B478CB000CED0E /* Debug */,
 				4D6801F816B478CB000CED0E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FAD106481D961E8900F81263 /* Build configuration list for PBXNativeTarget "Lockbox" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FAD106461D961E8900F81263 /* Debug */,
+				FAD106471D961E8900F81263 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/LockBox/LockBox.xcodeproj/xcshareddata/xcschemes/LockBox.xcscheme
+++ b/LockBox/LockBox.xcodeproj/xcshareddata/xcschemes/LockBox.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0800"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "2D0B9E5E1540556E00E5BE71"
-               BuildableName = "LockBox.app"
-               BlueprintName = "LockBox"
+               BlueprintIdentifier = "FAD106401D961E8900F81263"
+               BuildableName = "Lockbox.framework"
+               BlueprintName = "Lockbox"
                ReferencedContainer = "container:LockBox.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -26,33 +26,9 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4D6801E716B478CB000CED0E"
-               BuildableName = "UnitTests.xctest"
-               BlueprintName = "UnitTests"
-               ReferencedContainer = "container:LockBox.xcodeproj">
-            </BuildableReference>
-            <LocationScenarioReference
-               identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
-               referenceType = "1">
-            </LocationScenarioReference>
-         </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "2D0B9E5E1540556E00E5BE71"
-            BuildableName = "LockBox.app"
-            BlueprintName = "LockBox"
-            ReferencedContainer = "container:LockBox.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -66,16 +42,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "2D0B9E5E1540556E00E5BE71"
-            BuildableName = "LockBox.app"
-            BlueprintName = "LockBox"
+            BlueprintIdentifier = "FAD106401D961E8900F81263"
+            BuildableName = "Lockbox.framework"
+            BlueprintName = "Lockbox"
             ReferencedContainer = "container:LockBox.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -85,16 +60,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "2D0B9E5E1540556E00E5BE71"
-            BuildableName = "LockBox.app"
-            BlueprintName = "LockBox"
+            BlueprintIdentifier = "FAD106401D961E8900F81263"
+            BuildableName = "Lockbox.framework"
+            BlueprintName = "Lockbox"
             ReferencedContainer = "container:LockBox.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/LockBox/LockBox/Info.plist
+++ b/LockBox/LockBox/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>


### PR DESCRIPTION
We've added this to be able to pull the framework into our project via Carthage.  This would resolve #38.  If you want to merge it, please let me know what bundle identifier you'd like and I'll replace the following:

`PRODUCT_BUNDLE_IDENTIFIER = com.mytenten.Lockbox`
